### PR TITLE
install fish completion to vendor_completions.d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,8 @@ install-zsh: bin/auto-auto-complete.zsh
 
 .PHONY: install-fish
 install-fish: bin/auto-auto-complete.fish
-	install -dm755 -- "$(DESTDIR)$(DATADIR)/fish/completions"
-	install -m644 $< -- "$(DESTDIR)$(DATADIR)/fish/completions/$(COMMAND).fish"
+	install -dm755 -- "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d"
+	install -m644 $< -- "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/$(COMMAND).fish"
 
 
 # Uninstall rules


### PR DESCRIPTION
As noted in the docs[1], third-party software vendors should install
completion files into a different dir than upstream fish-shell to avoid
conflicts.  Docs suggest `/usr/share/fish/vendor_completions.d`.

This isn't an issue here (yet) but it conforms to the docs.

[1] https://fishshell.com/docs/current/#where-to-put-completions